### PR TITLE
Added metadata property

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ clean:
 	rm -rf dist
 	rm -rf $(VENV)
 
-.PHONY: gendoc
+.PHONY: docs
 docs: docs/source/*.rst
 	$(ACTIVATE); $(MAKE) -C $@ html
 

--- a/rawkit/metadata.py
+++ b/rawkit/metadata.py
@@ -1,0 +1,32 @@
+""":mod:`rawkit.metadata` --- Metadata structures
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+from collections import namedtuple
+
+
+Orientation = namedtuple('Orientation', [
+    'landscape',
+    'portrait',
+])(0, 1)
+"""
+Represents the orientation of an image. Either `landscape` or `portrait`.
+"""
+
+
+Metadata = namedtuple('Metadata', [
+    'aperture',
+    'timestamp',
+    'shutter',
+    'flash',
+    'focal_length',
+    'height',
+    'iso',
+    'make',
+    'model',
+    'orientation',
+    'width',
+])
+"""
+Common metadata for a photo.
+"""

--- a/rawkit/raw.py
+++ b/rawkit/raw.py
@@ -4,6 +4,7 @@
 
 import ctypes
 from rawkit.libraw import libraw
+from rawkit.metadata import Metadata
 
 
 class Raw(object):
@@ -121,3 +122,25 @@ class Raw(object):
         libraw.libraw_dcraw_clear_mem(processed_image)
 
         return data
+
+    @property
+    def metadata(self):
+        """
+        Common metadata for the photo
+
+        :returns: A metadata object
+        :rtype: :class:`~rawkit.metadata.Metadata`
+        """
+        return Metadata(
+            aperture=self.data.contents.other.aperture,
+            timestamp=self.data.contents.other.timestamp,
+            shutter=self.data.contents.other.shutter,
+            flash=bool(self.data.contents.color.flash_used),
+            focal_length=self.data.contents.other.focal_len,
+            height=self.data.contents.sizes.height,
+            iso=self.data.contents.other.iso_speed,
+            make=self.data.contents.idata.make,
+            model=self.data.contents.idata.model,
+            orientation=self.data.contents.sizes.flip,
+            width=self.data.contents.sizes.width,
+        )

--- a/tests/unit/raw_test.py
+++ b/tests/unit/raw_test.py
@@ -1,5 +1,6 @@
 import mock
 import pytest
+from rawkit.metadata import Metadata
 from rawkit.raw import Raw
 
 
@@ -113,3 +114,8 @@ def test_thumbnail_to_buffer(mock_libraw, raw):
     mock_libraw.libraw_dcraw_clear_mem.assert_called_once_with(
         mock_libraw.libraw_dcraw_make_mem_thumb(raw.data),
     )
+
+
+def test_metadata(mock_libraw, raw):
+    metadata = raw.metadata
+    assert type(metadata) is Metadata


### PR DESCRIPTION
Created a `metadata` property that has common fields for easy access. The goal is to make digging through the libraw structs unnecessary for most use cases.