### PR TITLE
Move generated docs to a subtree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ clean:
 	rm -rf $(VENV)
 
 .PHONY: docs
-docs: docs/source/*.rst
+docs: docs/source/api/*.rst
 	$(ACTIVATE); $(MAKE) -C $@ html
 
-docs/source/*.rst: rawkit/*.py $(VENV)
-	$(ACTIVATE); sphinx-apidoc -o docs/source rawkit docs
+docs/source/api/*.rst: rawkit/*.py $(VENV)
+	$(ACTIVATE); sphinx-apidoc -o docs/source/api rawkit docs

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,1 @@
-source/*.rst
+source/api/*.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,7 +20,7 @@ Contents
 .. toctree::
    :maxdepth: 2
 
-   rawkit
+   api/rawkit
 
 Indices and tables
 ==================


### PR DESCRIPTION
This way we can `.gitignore` the generated files only and actually add other docs w/o having to force add them.