### PR TITLE
Serializable options

### DIFF
--- a/rawkit/options.py
+++ b/rawkit/options.py
@@ -211,7 +211,7 @@ class Options(object):
         while True:
             idx += 1
             try:
-                yield self.__slots__[idx - 1][1:]
+                yield self.keys()[idx - 1]
             except IndexError:
                 raise StopIteration
 

--- a/rawkit/options.py
+++ b/rawkit/options.py
@@ -167,6 +167,10 @@ class Options(object):
 
     """
     Represents a set of options which can be used when processing raw data.
+
+    :param attrs: a subscriptable object from which to take the initial state
+                  of the options object.
+    :type attrs: :class:`dict`
     """
 
     __slots__ = [
@@ -189,12 +193,17 @@ class Options(object):
     ]
     """The options which are supported by this class."""
 
-    def __init__(self):
+    def __init__(self, attrs=None):
         """
-        Create the options object, initializing values to ``None``.
+        Create the options object, initializing values to ``None`` or their
+        corresponding value from `attrs`.
         """
         for i in self.__slots__:
-            setattr(self, i, None)
+            try:
+                param = i[1:]
+                setattr(self, param, attrs[param])
+            except (KeyError, TypeError):
+                setattr(self, i, None)
 
     def __iter__(self):
         """Allow iterating over the options."""

--- a/rawkit/options.py
+++ b/rawkit/options.py
@@ -215,6 +215,12 @@ class Options(object):
             except IndexError:
                 raise StopIteration
 
+    def __repr__(self):
+        """
+        Represents the options as a dict.
+        """
+        return repr(dict(self))
+
     def keys(self):
         """
         A list of keys which have a value other than ``None`` and which have

--- a/rawkit/options.py
+++ b/rawkit/options.py
@@ -196,6 +196,43 @@ class Options(object):
         for i in self.__slots__:
             setattr(self, i, None)
 
+    def __iter__(self):
+        """Allow iterating over the options."""
+        idx = 0
+        while True:
+            idx += 1
+            try:
+                yield self.__slots__[idx - 1][1:]
+            except IndexError:
+                raise StopIteration
+
+    def keys(self):
+        """
+        A list of keys which have a value other than ``None`` and which have
+        been set by the user (even if those options are set to the default
+        value).
+
+        :returns: List of option keys which have been set
+        :rtype: :class:`tuple`
+        """
+        return [slot[1:] for slot in self.__slots__ if getattr(self, slot) is
+                not None]
+
+    def values(self):
+        """
+        The values of all options which appear in :func:`keys`.
+
+        :returns: List of options values
+        :rtype: :class:`tuple`
+        """
+        return [self.__getitem__(k) for k in self.keys()]
+
+    def __getitem__(self, k):
+        """
+        Allow accessing options with dictionary syntax eg. opts['half_size'].
+        """
+        return getattr(self, k)
+
     @option(param='output_color', ctype=ctypes.c_int)
     def colorspace(self):
         """

--- a/tests/unit/options_test.py
+++ b/tests/unit/options_test.py
@@ -60,3 +60,27 @@ def test_map_params_fails_on_invalid(options):
     # with pytest.raises(AttributeError):
     params = Mock()
     options._map_to_libraw_params(params)
+
+
+def test_options_are_iterable(options):
+    options.half_size = True
+    assert 'half_size' in options
+    assert 'bps' not in options
+
+
+def test_options_repr(options):
+    options.half_size = True
+
+    assert repr(options) == repr({'half_size': True})
+
+
+def test_options_keys(options):
+    options.half_size = True
+
+    assert options.keys() == ['half_size']
+
+
+def test_options_values(options):
+    options.half_size = True
+
+    assert options.values() == [True]


### PR DESCRIPTION
This commit allows options to be serialized by the pyyaml and json packages by allowing options to behave like a dict under certain circumstances:

  - Options objects are now subscriptable (`options['white_balance']` works, but `options['white_balance'] = wb` throws a `TypeError`)
  - Options now have `values()`, and `keys()` (which return only the values/keys that have been set by the user, even if they're just set to the default value which would have been used / returned anyways)
  - `dict(opts)` now works as expected
  - Options can be initialized from a dict (with no key safety), eg. `Options({'white_balance': wb})`
  - `repr(opts)` is now equivalant to `repr(dict(opts))` (specifically for serializing JSON; may not work if WB or other sub-objects are set as it's not recursive)
  - Options are now iterable (`'half_size' in options` now works as expected)

Fixes #40