### PR TITLE
Add utility function for listing supported cameras

### DIFF
--- a/rawkit/util.py
+++ b/rawkit/util.py
@@ -1,3 +1,4 @@
+import ctypes
 import os
 
 from rawkit.libraw import libraw
@@ -21,3 +22,18 @@ def discover(path):
 
     libraw.libraw_close(raw)
     return file_list
+
+
+def camera_list():
+    """
+    Return a list of cameras which are supported by the currently linked
+    version of LibRaw.
+
+    :returns: A list of supported cameras
+    :rtype: :class:`basestring tuple`
+    """
+    libraw.libraw_cameraList.restype = ctypes.POINTER(
+        ctypes.c_char_p * libraw.libraw_cameraCount()
+    )
+    data_pointer = libraw.libraw_cameraList()
+    return [x.decode('ascii') for x in data_pointer.contents]

--- a/tests/unit/util_test.py
+++ b/tests/unit/util_test.py
@@ -1,7 +1,7 @@
 import mock
 import pytest
 
-from rawkit.util import discover
+from rawkit import util
 
 
 @pytest.yield_fixture
@@ -16,5 +16,14 @@ def test_discover(mock_libraw):
         return_value=(('', None, ('foo.CR2', 'foo.jpg')),)
     ):
         mock_libraw.libraw_open_file.side_effect = [0, 1]
-        files = discover('')
+        files = util.discover('')
         assert files == ['foo.CR2'.encode('ascii')]
+
+
+def test_camera_list(mock_libraw):
+    with mock.patch(
+        'rawkit.util.libraw.libraw_cameraCount',
+        return_value=0
+    ):
+        assert util.camera_list() == []
+        mock_libraw.libraw_cameraList.assert_called_once_with()


### PR DESCRIPTION
The test is more or less worthless. Othewise, does exactly what it says on the tin and provides a convenient utility function around `libraw_cameraList()`.