### PR TITLE
Add lightness option

### DIFF
--- a/rawkit/options.py
+++ b/rawkit/options.py
@@ -540,7 +540,7 @@ class Options(object):
         :type: :class:`int`
         :default: None
         :dcraw: `-W`
-        :libraw: :class:`rawkit.libraw.libraw_output_params_t.no_auto_bright`
+        :libraw: :class:`libraw.structs.libraw_output_params_t.no_auto_bright`
         """
         return None
 

--- a/rawkit/options.py
+++ b/rawkit/options.py
@@ -208,6 +208,7 @@ class Options(object):
         '_brightness',
         '_chromatic_aberration',
         '_darkness',
+        '_lightness',
         '_half_size',
         '_noise_threshold',
         '_rgbg_interpolation',
@@ -529,6 +530,19 @@ class Options(object):
         :libraw: :class:`rawkit.libraw.libraw_output_params_t.user_qual`
         """
         return interpolation.ahd
+
+    @option(param='no_auto_bright', ctype=ctypes.c_int)
+    def lightness(self):
+        """
+        Use a fixed white level. Defaults to automatically setting the white
+        level based on the image histogram.
+
+        :type: :class:`int`
+        :default: None
+        :dcraw: `-W`
+        :libraw: :class:`rawkit.libraw.libraw_output_params_t.no_auto_bright`
+        """
+        return None
 
     def _map_to_libraw_params(self, params):
         """


### PR DESCRIPTION
Adds a `lightness` option (manually set the white level instead of automatically correcting it based on the histogram).

**This is a bit weird, because it's an absolute option in dcraw / libraw, but darkness is addative (ontop of whatever the automatic value is), and even thought they're not really the same thing you'd sort of expect them to behave the same way.**

Maybe we should set this to the automatic value, and then add whatever the user sets (including negative) to that so that they're the same? Or make darkness automatic unless the user sets it and then make it absolute.

Possibly blocking on #51 depending on what we decide to do.