### PR TITLE
Libraw errors

### DIFF
--- a/rawkit/errors.py
+++ b/rawkit/errors.py
@@ -1,0 +1,64 @@
+class LibrawUnspecifiedError(Exception):
+    pass
+
+
+class LibrawFileUnsupported(Exception):
+    pass
+
+
+class LibrawRequestForNonexistentImage(Exception):
+    pass
+
+
+class LibrawOutOfOrderCall(Exception):
+    pass
+
+
+class LibrawNoThumbnail(Exception):
+    pass
+
+
+class LibrawUnsupportedThumbnail(Exception):
+    pass
+
+
+class LibrawInputClosed(Exception):
+    pass
+
+
+class LibrawInsufficientMemory(Exception):
+    pass
+
+
+class LibrawDataError(Exception):
+    pass
+
+
+class LibrawIOError(Exception):
+    pass
+
+
+class LibrawCancelledByCallback(Exception):
+    pass
+
+
+class LibrawBadCrop(Exception):
+    pass
+
+
+def check_call(exit_code):
+    if exit_code is not 0:
+        raise {
+            -1: LibrawUnspecifiedError,
+            -2: LibrawFileUnsupported,
+            -3: LibrawRequestForNonexistentImage,
+            -4: LibrawOutOfOrderCall,
+            -5: LibrawNoThumbnail,
+            -6: LibrawUnsupportedThumbnail,
+            -7: LibrawInputClosed,
+            -100007: LibrawInsufficientMemory,
+            -100008: LibrawDataError,
+            -100009: LibrawIOError,
+            -100010: LibrawCancelledByCallback,
+            -100011: LibrawBadCrop
+        }[exit_code]

--- a/rawkit/raw.py
+++ b/rawkit/raw.py
@@ -4,6 +4,7 @@
 
 import ctypes
 
+from rawkit import errors as e
 from rawkit.libraw import libraw
 from rawkit.metadata import Metadata
 from rawkit.options import Options
@@ -34,7 +35,9 @@ class Raw(object):
     def __init__(self, filename=None):
         """Initializes a new Raw object."""
         self.data = libraw.libraw_init(0)
-        libraw.libraw_open_file(self.data, filename.encode('ascii'))
+        e.check_call(
+            libraw.libraw_open_file(self.data, filename.encode('ascii'))
+        )
 
         self.options = Options()
 
@@ -51,24 +54,24 @@ class Raw(object):
 
     def close(self):
         """Free the underlying raw representation."""
-        libraw.libraw_close(self.data)
+        e.check_call(libraw.libraw_close(self.data))
 
     def unpack(self):
         """Unpack the raw data."""
         if not self.image_unpacked:
-            libraw.libraw_unpack(self.data)
+            e.check_call(libraw.libraw_unpack(self.data))
             self.image_unpacked = True
 
     def unpack_thumb(self):
         """Unpack the thumbnail data."""
         if not self.thumb_unpacked:
-            libraw.libraw_unpack_thumb(self.data)
+            e.check_call(libraw.libraw_unpack_thumb(self.data))
             self.thumb_unpacked = True
 
     def process(self):
         """Process the raw data based on self.options"""
         self.options._map_to_libraw_params(self.data.contents.params)
-        libraw.libraw_dcraw_process(self.data)
+        e.check_call(libraw.libraw_dcraw_process(self.data))
 
     def save(self, filename=None, filetype='ppm'):
         """
@@ -85,8 +88,8 @@ class Raw(object):
         self.unpack()
         self.process()
 
-        libraw.libraw_dcraw_ppm_tiff_writer(
-            self.data, filename.encode('ascii'))
+        e.check_call(libraw.libraw_dcraw_ppm_tiff_writer(
+            self.data, filename.encode('ascii')))
 
     def save_thumb(self, filename=None):
         """
@@ -97,8 +100,8 @@ class Raw(object):
         """
         self.unpack_thumb()
 
-        libraw.libraw_dcraw_thumb_writer(
-            self.data, filename.encode('ascii'))
+        e.check_call(libraw.libraw_dcraw_thumb_writer(
+            self.data, filename.encode('ascii')))
 
     def to_buffer(self):
         """
@@ -116,7 +119,7 @@ class Raw(object):
             ctypes.POINTER(ctypes.c_byte * processed_image.contents.data_size)
         )
         data = bytearray(data_pointer.contents)
-        libraw.libraw_dcraw_clear_mem(processed_image)
+        e.check_call(libraw.libraw_dcraw_clear_mem(processed_image))
 
         return data
 
@@ -135,7 +138,7 @@ class Raw(object):
             ctypes.POINTER(ctypes.c_byte * processed_image.contents.data_size)
         )
         data = bytearray(data_pointer.contents)
-        libraw.libraw_dcraw_clear_mem(processed_image)
+        e.check_call(libraw.libraw_dcraw_clear_mem(processed_image))
 
         return data
 

--- a/tests/unit/error_test.py
+++ b/tests/unit/error_test.py
@@ -1,0 +1,13 @@
+import pytest
+
+from rawkit.errors import check_call
+from rawkit.errors import LibrawUnspecifiedError
+
+
+def test_check_call_success():
+    check_call(0)
+
+
+def test_check_call_error():
+    with pytest.raises(LibrawUnspecifiedError):
+        check_call(-1)

--- a/tests/unit/raw_test.py
+++ b/tests/unit/raw_test.py
@@ -5,7 +5,13 @@ from rawkit.raw import Raw
 
 
 @pytest.yield_fixture
-def mock_libraw():
+def mock_check_call():
+    with mock.patch('rawkit.raw.e') as check_call:
+        yield check_call
+
+
+@pytest.yield_fixture
+def mock_libraw(mock_check_call):
     with mock.patch('rawkit.raw.libraw') as libraw:
         yield libraw
 


### PR DESCRIPTION
This is based on gpennell's error handling branch.

I removed UndefinedLibrawError and just let check_call fail with a key error if it gets an unknown return code, because that should be impossible anyway.

All remaining exception classes are consistently named based on the names in LIbRaw, with the exception of `LibrawInsufficientMemory` (I couldn't live with calling it `LibrawUnsufficientMemory`).

Tests were added/updated as necessary and style changes were made to conform with PEP-8.