### PR TITLE
Customize rawkit errors and don't use asserts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ target/
 
 # Vim
 *.swp
+
+test-results/

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ upload: build test
 clean:
 	$(ACTIVATE); $(MAKE) -C docs $@
 	find . -iname '*.pyc' | xargs rm -f
-	rm -rf docs/source/api/*
+	find . -iname '__pycache__' -type d | xargs rm -rf
 	rm -rf .tox
 	rm -rf dist
 	rm -rf $(VENV)

--- a/docs/source/api/rawkit.rst
+++ b/docs/source/api/rawkit.rst
@@ -9,6 +9,14 @@ rawkit package
 Submodules
 ----------
 
+rawkit.errors module
+----------------------
+
+.. automodule:: rawkit.errors
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 rawkit.metadata module
 ----------------------
 

--- a/rawkit/errors.py
+++ b/rawkit/errors.py
@@ -1,0 +1,24 @@
+""":mod:`rawkit.errors` --- Errors thrown by rawkit
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These errors are thrown by various rawkit functions and methods when things go
+wrong. They will only be raised by rawkit; for lower level errors raised by the
+underlying libraw bindings, see :class:`libraw.errors`.
+"""
+
+
+class InvalidFileType(ValueError):
+
+    """
+    Raised when an invalid file type or file extension is passed to a rawkit
+    method. If rawkit does not know what the filetype is, a
+    :exc:`libraw.errors.FileUnsupported` may be raised instead.
+    """
+
+
+class NoFileSpecified(ValueError):
+
+    """
+    Raised when the method or function excpects a `filename` argument, but no
+    file name (or a value of `None`) was specified.
+    """

--- a/rawkit/raw.py
+++ b/rawkit/raw.py
@@ -7,6 +7,8 @@ import ctypes
 from libraw import libraw
 from libraw import errors as e
 
+
+from rawkit.errors import NoFileSpecified, InvalidFileType
 from rawkit.metadata import Metadata
 from rawkit.options import Options
 
@@ -31,10 +33,13 @@ class Raw(object):
     :type filename: :class:`str`
     :returns: A raw object
     :rtype: :class:`Raw`
+    :raises: :exc:`rawkit.errors.NoFileSpecified`
     """
 
     def __init__(self, filename=None):
         """Initializes a new Raw object."""
+        if filename is None:
+            raise NoFileSpecified()
         self.data = libraw.libraw_init(0)
         e.check_call(
             libraw.libraw_open_file(self.data, filename.encode('ascii'))
@@ -82,8 +87,13 @@ class Raw(object):
         :type filename: :class:`str`
         :param filetype: the type of file to output (``ppm`` or ``tiff``)
         :type filetype: :class:`str`
+        :raises: :exc:`rawkit.errors.NoFileSpecified`
+                 :exc:`rawkit.errors.InvalidFileTypeError`
         """
-        assert filetype in ('ppm', 'tiff')
+        if filename is None:
+            raise NoFileSpecified()
+        if filetype not in ('ppm', 'tiff'):
+            raise InvalidFileType('Output filetype must be "ppm" or "tiff"')
         self.data.contents.params.output_tiff = 0 if filetype is 'ppm' else 1
 
         self.unpack()

--- a/tests/unit/raw_test.py
+++ b/tests/unit/raw_test.py
@@ -1,5 +1,6 @@
 import mock
 import pytest
+from rawkit.errors import InvalidFileType, NoFileSpecified
 from rawkit.metadata import Metadata
 from rawkit.raw import Raw
 
@@ -41,6 +42,11 @@ def test_create(mock_libraw, raw, input_file):
     )
 
 
+def test_create_no_filename(mock_libraw):
+    with pytest.raises(NoFileSpecified):
+        Raw()
+
+
 def test_unpack(mock_libraw, raw):
     raw.unpack()
     mock_libraw.libraw_unpack.assert_called_once_with(raw.data)
@@ -72,6 +78,11 @@ def _test_save(mock_libraw, raw, output_file, filetype):
     )
 
 
+def test_save_no_filename(mock_libraw, raw):
+    with pytest.raises(NoFileSpecified):
+        raw.save(filetype='ppm')
+
+
 def test_save_ppm(mock_libraw, raw, output_file):
     _test_save(mock_libraw, raw, output_file, 'ppm')
 
@@ -81,7 +92,7 @@ def test_save_tiff(mock_libraw, raw, output_file):
 
 
 def test_save_invalid(mock_libraw, raw, output_file):
-    with pytest.raises(AssertionError):
+    with pytest.raises(InvalidFileType):
         _test_save(mock_libraw, raw, output_file, 'jpg')
 
 


### PR DESCRIPTION
Customize the error when no filename is specified (so that we don't have confusing errors when it tries to do `None.encode('ascii')`).

Swaps out an assert for a custom error as well so that the end user can actually handle errors on it properly and not risk catching other random errors (not that much could have happened in this specific instancee).