### PR TITLE
Dark frame option

### DIFF
--- a/libraw/structs.py
+++ b/libraw/structs.py
@@ -161,7 +161,7 @@ class libraw_output_params_t(Structure):
         ('output_profile', POINTER(c_char)),
         ('camera_profile', POINTER(c_char)),
         ('bad_pixels', POINTER(c_char)),
-        ('dark_frame', POINTER(c_char)),
+        ('dark_frame', c_char_p),
         ('output_bps', c_int),
         ('output_tiff', c_int),
         ('user_flip', c_int),

--- a/rawkit/options.py
+++ b/rawkit/options.py
@@ -223,6 +223,7 @@ class Options(object):
         '_interpolation',
         '_auto_stretch',
         '_rotation',
+        '_dark_frame',
     ]
     """The options which are supported by this class."""
 
@@ -604,6 +605,36 @@ class Options(object):
             90: 6,
             0: 0
         }[self._rotation])
+
+    @option
+    def dark_frame(self):
+        """
+        A dark frame in 16-bit PGM format. This may either be a path to an
+        existing file, or an instance of :class:`rawkit.raw.DarkFrame`.
+
+        :type: :class:`rawkit.raw.DarkFrame`
+               :class:`str`
+        :default: None
+        :dcraw: ``-K``
+        :libraw: :class:`libraw.structs.libraw_output_params_t.dark_frame`
+        """
+        return None
+
+    @dark_frame.setter
+    def dark_frame(self, value):
+        self._dark_frame = value
+
+    @dark_frame.param_writer
+    def dark_frame(self, params):
+        try:
+            self._dark_frame.save()
+            params.dark_frame = ctypes.c_char_p(
+                self._dark_frame.tmp.encode('utf-8')
+            )
+        except AttributeError:
+            params.dark_frame = ctypes.c_char_p(
+                self._dark_frame.encode('utf-8')
+            )
 
     def _map_to_libraw_params(self, params):
         """

--- a/rawkit/options.py
+++ b/rawkit/options.py
@@ -629,7 +629,7 @@ class Options(object):
         try:
             self._dark_frame.save()
             params.dark_frame = ctypes.c_char_p(
-                self._dark_frame.tmp.encode('utf-8')
+                self._dark_frame.name.encode('utf-8')
             )
         except AttributeError:
             params.dark_frame = ctypes.c_char_p(

--- a/tests/unit/options_test.py
+++ b/tests/unit/options_test.py
@@ -139,7 +139,8 @@ def test_dark_frame_writer(options):
     assert params.dark_frame.value == b'Some String'
 
     df = Mock()
-    df.tmp = 'fakefile'
+    df._tmp = 'fakefile'
+    df.name = df._tmp
     options.dark_frame = df
     params = options._map_to_libraw_params(Mock())
     assert params.dark_frame.value == b'fakefile'

--- a/tests/unit/options_test.py
+++ b/tests/unit/options_test.py
@@ -3,8 +3,6 @@ import pytest
 from mock import Mock
 from rawkit.options import option, Options, WhiteBalance
 
-# @option decorator tests
-
 
 @pytest.fixture
 def options():
@@ -128,3 +126,20 @@ def test_auto_brightness_param_writer(options):
     options.auto_brightness = False
     params = options._map_to_libraw_params(Mock())
     assert params.no_auto_bright.value == 1
+
+
+def test_dark_frame_setter(options):
+    options.dark_frame = 'Some String'
+    assert options._dark_frame == 'Some String'
+
+
+def test_dark_frame_writer(options):
+    options.dark_frame = 'Some String'
+    params = options._map_to_libraw_params(Mock())
+    assert params.dark_frame.value == b'Some String'
+
+    df = Mock()
+    df.tmp = 'fakefile'
+    options.dark_frame = df
+    params = options._map_to_libraw_params(Mock())
+    assert params.dark_frame.value == b'fakefile'


### PR DESCRIPTION
Adds a naive dark frame implementation (just creates a temporary file and saves it).

Has minimal optimizations (it checks if the temp file already exists, and if so doesn't process / save the file again). Not very good.

Should be improved later with FIFO support on Unix based systems (will require us to rething parts of the system though since that will require some threading magic since named pipes are blocking).