### PR TITLE
Allow customizing the auto_brightness option

### DIFF
--- a/rawkit/options.py
+++ b/rawkit/options.py
@@ -207,6 +207,7 @@ class Options(object):
         '_bps',
         '_brightness',
         '_auto_brightness',
+        '_auto_brightness_threshold',
         '_chromatic_aberration',
         '_darkness',
         '_half_size',
@@ -529,7 +530,8 @@ class Options(object):
     @option(param='bright', ctype=ctypes.c_float)
     def brightness(self):
         """
-        Sets the brightness level.
+        Sets the brightness level by dividing the white level by this value.
+        This is ignored if :class:`~auto_brightness` is ``True``.
 
         :type: :class:`float`
         :default: 1.0
@@ -538,28 +540,35 @@ class Options(object):
         """
         return 1.0
 
-    @option
-    def auto_brightness(self):
+    @option(param='auto_bright_thr', ctype=ctypes.c_float)
+    def auto_brightness_threshold(self):
         """
-        If set to an allowable percentage of clipped pixels, sets the
-        brightness automatically based on the image histogram. Otherwise (None)
-        use a fixed brightness level.
+        The allowable percentage of clipped pixels when
+        :class:`~auto_brightness` is used.
 
         :type: :class:`float`
         :default: 0.001 (0.1%)
-        :dcraw: ``-W``
-        :libraw: :class:`libraw.structs.libraw_output_params_t.no_auto_bright`
-                 :class:`libraw.structs.libraw_output_params_t.auto_bright_thr`
+        :dcraw: None
+        :libraw: :class:`libraw.structs.libraw_output_params_t.auto_bright_thr`
         """
         return 0.001
 
+    @option
+    def auto_brightness(self):
+        """
+        Set the brightness automatically based on the image histogram and the
+        :class:`~auto_brightness_threshold`.
+
+        :type: :class:`boolean`
+        :default: True
+        :dcraw: ``-W``
+        :libraw: :class:`libraw.structs.libraw_output_params_t.no_auto_bright`
+        """
+        return True
+
     @auto_brightness.param_writer
-    def auto_brightness(self, params):
-        if self._auto_brightness is None:
-            params.no_auto_bright = ctypes.c_int(True)
-        else:
-            params.no_auto_bright = ctypes.c_int(False)
-            params.auto_bright_thr = ctypes.c_float(self._auto_brightness)
+    def auto_brightness(self, param):
+        param.no_auto_bright = ctypes.c_int(not self._auto_brightness)
 
     @option(param='use_fuji_rotate', ctype=ctypes.c_int)
     def auto_stretch(self):

--- a/rawkit/options.py
+++ b/rawkit/options.py
@@ -526,7 +526,7 @@ class Options(object):
         """
         return interpolation.ahd
 
-    @option('bright', ctype=ctypes.c_float)
+    @option(param='bright', ctype=ctypes.c_float)
     def brightness(self):
         """
         Sets the brightness level.
@@ -541,21 +541,25 @@ class Options(object):
     @option
     def auto_brightness(self):
         """
-        Sets the brightness automatically based on the image histogram.
+        If set to an allowable percentage of clipped pixels, sets the
+        brightness automatically based on the image histogram. Otherwise (None)
+        use a fixed brightness level.
 
-        :type: :class:`boolean`
-        :default: True
+        :type: :class:`float`
+        :default: 0.001 (0.1%)
         :dcraw: ``-W``
         :libraw: :class:`libraw.structs.libraw_output_params_t.no_auto_bright`
+                 :class:`libraw.structs.libraw_output_params_t.auto_bright_thr`
         """
-        return True
+        return 0.001
 
     @auto_brightness.param_writer
     def auto_brightness(self, params):
         if self._auto_brightness is None:
-            params.no_auto_bright = ctypes.c_int(False)
+            params.no_auto_bright = ctypes.c_int(True)
         else:
-            params.no_auto_bright = ctypes.c_int(not self._auto_brightness)
+            params.no_auto_bright = ctypes.c_int(False)
+            params.auto_bright_thr = ctypes.c_float(self._auto_brightness)
 
     @option(param='use_fuji_rotate', ctype=ctypes.c_int)
     def auto_stretch(self):

--- a/tests/unit/options_test.py
+++ b/tests/unit/options_test.py
@@ -117,15 +117,12 @@ def test_rotation_param_writer_values(options):
 def test_auto_brightness_param_writer(options):
     options.auto_brightness = None
     params = options._map_to_libraw_params(Mock())
-    assert params.no_auto_bright.value == 0
-
-    options.auto_brightness = True
-    params = options._map_to_libraw_params(Mock())
-    assert params.no_auto_bright.value == 0
-
-    options.auto_brightness = False
-    params = options._map_to_libraw_params(Mock())
     assert params.no_auto_bright.value == 1
+
+    options.auto_brightness = 0.1
+    params = options._map_to_libraw_params(Mock())
+    assert params.no_auto_bright.value == 0
+    assert abs(params.auto_bright_thr.value - 0.1) < 0.000001
 
 
 def test_dark_frame_setter(options):

--- a/tests/unit/options_test.py
+++ b/tests/unit/options_test.py
@@ -114,17 +114,6 @@ def test_rotation_param_writer_values(options):
         assert params.user_flip.value == values[value]
 
 
-def test_auto_brightness_param_writer(options):
-    options.auto_brightness = None
-    params = options._map_to_libraw_params(Mock())
-    assert params.no_auto_bright.value == 1
-
-    options.auto_brightness = 0.1
-    params = options._map_to_libraw_params(Mock())
-    assert params.no_auto_bright.value == 0
-    assert abs(params.auto_bright_thr.value - 0.1) < 0.000001
-
-
 def test_dark_frame_setter(options):
     options.dark_frame = 'Some String'
     assert options._dark_frame == 'Some String'


### PR DESCRIPTION
Allows the user to set the threshold of clipped pixels allowed by the
auto_brightness option.

~~After I did this, I realized that it might be confusing. Should this option be renamed, or should it be split into two options, or is it fine and it should be left alone?~~ Fixed.