### PR TITLE
Add argtypes and callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,6 @@ docs/_build/
 target/
 
 # Vim
-*.swp
+*.sw[po]
 
 test-results/

--- a/libraw/bindings.py
+++ b/libraw/bindings.py
@@ -147,7 +147,7 @@ class LibRaw(CDLL):
             ]
             self.libraw_open_wfile_ex.argtypes = [
                 POINTER(libraw_data_t),
-                c_char_p,
+                c_wchar_p,
                 c_int64
             ]
             self.libraw_open_wfile.restype = c_error

--- a/libraw/bindings.py
+++ b/libraw/bindings.py
@@ -8,8 +8,9 @@ from ctypes import *  # noqa
 from ctypes import util
 
 from libraw import errors
+from libraw.callbacks import data_callback, exif_parser_callback, memory_callback, progress_callback
 from libraw.errors import c_error
-from libraw.structs import libraw_data_t, libraw_processed_image_t
+from libraw.structs import libraw_data_t, libraw_decoder_info_t, libraw_processed_image_t
 
 
 class LibRaw(CDLL):
@@ -28,6 +29,85 @@ class LibRaw(CDLL):
                 raise ImportError
         except (ImportError, AttributeError, OSError, IOError):
             raise ImportError('Cannot find LibRaw on your system!')
+
+        # Define arg types
+
+        self.libraw_init.argtypes = [c_int]
+        # enum LibRaw_progress
+        self.libraw_strprogress.argtypes = [c_int]
+        self.libraw_unpack_function_name.argtypes = [POINTER(libraw_data_t)]
+
+        self.libraw_subtract_black.argtypes = [POINTER(libraw_data_t)]
+        self.libraw_open_file.argtypes = [POINTER(libraw_data_t), c_char_p]
+        self.libraw_open_file_ex.argtypes = [
+            POINTER(libraw_data_t),
+            c_char_p,
+            c_int64
+        ]
+        self.libraw_open_buffer.argtypes = [
+            POINTER(libraw_data_t),
+            c_void_p,
+            c_int64
+        ]
+        self.libraw_unpack.argtypes = [POINTER(libraw_data_t)]
+        self.libraw_unpack_thumb.argtypes = [POINTER(libraw_data_t)]
+        self.libraw_recycle_datastream.argtypes = [POINTER(libraw_data_t)]
+        self.libraw_recycle.argtypes = [POINTER(libraw_data_t)]
+        self.libraw_close.argtypes = [POINTER(libraw_data_t)]
+        self.libraw_set_exifparser_handler.argtypes = [
+            POINTER(libraw_data_t),
+            exif_parser_callback,
+            c_void_p,
+        ]
+        self.libraw_set_memerror_handler.argtypes = [
+            POINTER(libraw_data_t),
+            memory_callback,
+            c_void_p,
+        ]
+        self.libraw_set_dataerror_handler.argtypes = [
+            POINTER(libraw_data_t),
+            data_callback,
+            c_void_p,
+        ]
+        self.libraw_set_progress_handler.argtypes = [
+            POINTER(libraw_data_t),
+            progress_callback,
+            c_void_p,
+        ]
+        self.libraw_adjust_sizes_info_only.argtypes = [
+            POINTER(libraw_data_t)
+        ]
+        self.libraw_dcraw_ppm_tiff_writer.argtypes = [
+            POINTER(libraw_data_t),
+            c_char_p
+        ]
+        self.libraw_dcraw_thumb_writer.argtypes = [
+            POINTER(libraw_data_t),
+            c_char_p
+        ]
+        self.libraw_dcraw_process.argtypes = [POINTER(libraw_data_t)]
+        self.libraw_dcraw_make_mem_image.argtypes = [
+            POINTER(libraw_data_t),
+            c_int
+        ]
+        self.libraw_dcraw_make_mem_thumb.argtypes = [
+            POINTER(libraw_data_t),
+            c_int
+        ]
+        self.libraw_dcraw_clear_mem.argtypes = [
+            POINTER(libraw_processed_image_t)
+        ]
+        self.libraw_raw2image.argtypes = [POINTER(libraw_data_t)]
+        self.libraw_free_image.argtypes = [POINTER(libraw_data_t)]
+        self.libraw_get_decoder_info.argtypes = [
+            POINTER(libraw_data_t),
+            POINTER(libraw_decoder_info_t)
+        ]
+        self.libraw_COLOR.argtypes = [
+            POINTER(libraw_data_t),
+            c_int,
+            c_int
+        ]
 
         # Define return types
 
@@ -57,7 +137,19 @@ class LibRaw(CDLL):
         self.libraw_raw2image.restype = c_error
         self.libraw_get_decoder_info.restype = c_error
         self.libraw_COLOR.restype = c_error
+
+        # Some special Windows-only garbage:
+
         try:
+            self.libraw_open_wfile.argtypes = [
+                POINTER(libraw_data_t),
+                c_wchar_p
+            ]
+            self.libraw_open_wfile_ex.argtypes = [
+                POINTER(libraw_data_t),
+                c_char_p,
+                c_int64
+            ]
             self.libraw_open_wfile.restype = c_error
             self.libraw_open_wfile_ex.restype = c_error
         except AttributeError:

--- a/libraw/callbacks.py
+++ b/libraw/callbacks.py
@@ -1,0 +1,119 @@
+""":mod:`libraw.callbacks` --- LibRaw callback definitions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Note that you will need to keep a reference to your callback functions for as
+long as you want to call them from C code, otherwise they may be garbage
+collected and lead to a segmentation fault.
+"""
+
+from ctypes import *  # noqa
+
+exif_parser_callback = CFUNCTYPE(
+    c_void_p, c_int, c_int, c_int, c_int, c_void_p
+)
+"""
+Creates a callback for use by the EXIF parser.
+
+.. sourcecode:: python
+
+    def exif_cb(context, tag, type, len, ord, ifp):
+        pass
+
+    cb = CFUNCTYPE(exif_cb)
+
+    libraw.libraw_set_exifparser_handler(libraw_data, cb, data)
+
+Your callback function should map to the LibRaw C callback definition below:
+
+.. sourcecode:: c
+
+    typedef void (*exif_parser_callback) (
+        void *context, int tag, int type, int len, unsigned int ord, void *ifp
+    );
+
+:param callback: the Python function to convert to a C callback.
+:type callback: :class:`function`
+:returns: A C callback
+:rtype: :class:`_ctypes.PyCFuncPtrType`
+"""
+
+memory_callback = CFUNCTYPE(c_void_p, c_char_p, c_char_p)
+"""
+Creates a callback for use when there are memory errors in LibRaw.
+
+.. sourcecode:: python
+
+    def memory_cb(data, file, where):
+        pass
+
+    cb = CFUNCTYPE(memory_cb)
+
+    libraw.libraw_set_memerror_handler(libraw_data, cb, data)
+
+Your callback function should map to the LibRaw C callback definition below:
+
+.. sourcecode:: c
+
+    typedef void (*memory_callback) (
+        void *data, const char *file, const char *where
+    );
+
+:param callback: the Python function to convert to a C callback.
+:type callback: :class:`function`
+:returns: A C callback
+:rtype: :class:`_ctypes.PyCFuncPtrType`
+"""
+
+data_callback = CFUNCTYPE(c_void_p, c_char_p, c_int)
+"""
+A callback for use when there are data errors in LibRaw.
+
+.. sourcecode:: python
+
+    def data_cb(data, file, offset):
+        pass
+
+    cb = CFUNCTYPE(data_cb)
+
+    libraw.libraw_set_dataerror_handler(libraw_data, cb, data)
+
+Your callback function should map to the LibRaw C callback definition below:
+
+.. sourcecode:: c
+
+    typedef void (*data_callback) (
+        void *data, const char *file, const int offset
+    );
+
+:param callback: the Python function to convert to a C callback.
+:type callback: :class:`function`
+:returns: A C callback
+:rtype: :class:`_ctypes.PyCFuncPtrType`
+"""
+
+progress_callback = CFUNCTYPE(c_void_p, c_int, c_int, c_int)
+"""
+A callback that will be called to alert you to the stages of image processing.
+
+.. sourcecode:: python
+
+    def progress_cb(data, stage, iteration, expected):
+        pass
+
+    cb = CFUNCTYPE(progress_cb)
+
+    libraw.libraw_set_progress_handler(libraw_data, cb, data)
+
+Your callback function should map to the LibRaw C callback definition below:
+
+.. sourcecode:: c
+
+    typedef void (*progress_callback) (
+        void *data, enum LibRaw_progress stage, int iterationa, int expected
+    );
+
+:param callback: the Python function to convert to a C callback.
+:type callback: :class:`function`
+:returns: A C callback
+:rtype: :class:`_ctypes.PyCFuncPtrType`
+"""

--- a/libraw/callbacks.py
+++ b/libraw/callbacks.py
@@ -19,7 +19,7 @@ Creates a callback for use by the EXIF parser.
     def exif_cb(context, tag, type, len, ord, ifp):
         pass
 
-    cb = CFUNCTYPE(exif_cb)
+    cb = exif_parser_callback(exif_cb)
 
     libraw.libraw_set_exifparser_handler(libraw_data, cb, data)
 
@@ -46,7 +46,7 @@ Creates a callback for use when there are memory errors in LibRaw.
     def memory_cb(data, file, where):
         pass
 
-    cb = CFUNCTYPE(memory_cb)
+    cb = memory_callback(memory_cb)
 
     libraw.libraw_set_memerror_handler(libraw_data, cb, data)
 
@@ -73,7 +73,7 @@ A callback for use when there are data errors in LibRaw.
     def data_cb(data, file, offset):
         pass
 
-    cb = CFUNCTYPE(data_cb)
+    cb = data_callback(data_cb)
 
     libraw.libraw_set_dataerror_handler(libraw_data, cb, data)
 
@@ -100,7 +100,7 @@ A callback that will be called to alert you to the stages of image processing.
     def progress_cb(data, stage, iteration, expected):
         pass
 
-    cb = CFUNCTYPE(progress_cb)
+    cb = progress_callback(progress_cb)
 
     libraw.libraw_set_progress_handler(libraw_data, cb, data)
 

--- a/libraw/structs.py
+++ b/libraw/structs.py
@@ -237,3 +237,12 @@ class libraw_processed_image_t(Structure):
         ('data_size', c_uint),
         ('data', c_byte * 1),
     ]
+
+
+class libraw_decoder_info_t(Structure):
+
+    """Describes a raw format decoder name and format."""
+    _fields_ = [
+        ('decoder_name', c_char_p),
+        ('decoder_flags', c_uint),
+    ]


### PR DESCRIPTION
Adds the arg types to the LibRaw functions (so that we will get a nice error in Python land if they're specified wrong instead of a segfault in C land), and adds a struct and several callback types.