### PR TITLE
Fixed thumbnail methods and flattened imports

### DIFF
--- a/libraw/bindings.py
+++ b/libraw/bindings.py
@@ -8,9 +8,13 @@ from ctypes import *  # noqa
 from ctypes import util
 
 from libraw import errors
-from libraw.callbacks import data_callback, memory_callback, progress_callback
+from libraw.callbacks import data_callback
+from libraw.callbacks import memory_callback
+from libraw.callbacks import progress_callback
 from libraw.errors import c_error
-from libraw.structs import libraw_data_t, libraw_decoder_info_t, libraw_processed_image_t
+from libraw.structs import libraw_data_t
+from libraw.structs import libraw_decoder_info_t
+from libraw.structs import libraw_processed_image_t
 
 
 class LibRaw(CDLL):
@@ -83,11 +87,11 @@ class LibRaw(CDLL):
         self.libraw_dcraw_process.argtypes = [POINTER(libraw_data_t)]
         self.libraw_dcraw_make_mem_image.argtypes = [
             POINTER(libraw_data_t),
-            c_int
+            POINTER(c_int)
         ]
         self.libraw_dcraw_make_mem_thumb.argtypes = [
             POINTER(libraw_data_t),
-            c_int
+            POINTER(c_int)
         ]
         self.libraw_dcraw_clear_mem.argtypes = [
             POINTER(libraw_processed_image_t)

--- a/rawkit/raw.py
+++ b/rawkit/raw.py
@@ -8,7 +8,8 @@ import random
 import string
 import tempfile
 
-from rawkit.errors import NoFileSpecified, InvalidFileType
+from rawkit.errors import InvalidFileType
+from rawkit.errors import NoFileSpecified
 from libraw.bindings import LibRaw
 
 from rawkit.metadata import Metadata
@@ -136,7 +137,11 @@ class Raw(object):
         self.unpack()
         self.process()
 
-        processed_image = self.libraw.libraw_dcraw_make_mem_image(self.data)
+        # TODO: check the error code stored in the provided int pointer
+        processed_image = self.libraw.libraw_dcraw_make_mem_image(
+            self.data,
+            ctypes.byref(ctypes.c_int()),
+        )
         data_pointer = ctypes.cast(
             processed_image.contents.data,
             ctypes.POINTER(ctypes.c_byte * processed_image.contents.data_size)
@@ -155,7 +160,11 @@ class Raw(object):
         """
         self.unpack_thumb()
 
-        processed_image = self.libraw.libraw_dcraw_make_mem_thumb(self.data)
+        # TODO: check the error code stored in the provided int pointer
+        processed_image = self.libraw.libraw_dcraw_make_mem_thumb(
+            self.data,
+            ctypes.byref(ctypes.c_int()),
+        )
         data_pointer = ctypes.cast(
             processed_image.contents.data,
             ctypes.POINTER(ctypes.c_byte * processed_image.contents.data_size)

--- a/tests/unit/raw_test.py
+++ b/tests/unit/raw_test.py
@@ -141,6 +141,7 @@ def test_to_buffer(raw):
 
     raw.libraw.libraw_dcraw_make_mem_image.assert_called_once_with(
         raw.data,
+        mock.ANY,
     )
 
     raw.libraw.libraw_dcraw_clear_mem.assert_called_once_with(
@@ -155,6 +156,7 @@ def test_thumbnail_to_buffer(raw):
 
     raw.libraw.libraw_dcraw_make_mem_thumb.assert_called_once_with(
         raw.data,
+        mock.ANY,
     )
 
     raw.libraw.libraw_dcraw_clear_mem.assert_called_once_with(


### PR DESCRIPTION
I swear these methods were working in the past, but LibRaw's git history says `libraw_dcraw_make_mem_image` and `libraw_dcraw_make_mem_thumb` have always taken an int as a second parameter.

I also flattened out all the imports because it makes them easier to edit and confuses git less.