### PR TITLE
Check error codes for the make_mem... functions

### DIFF
--- a/libraw/errors.py
+++ b/libraw/errors.py
@@ -124,7 +124,14 @@ def check_call(exit_code, func, arguments):
         BadCrop: The crop range was invalid.
     """
 
-    if func.restype is c_error and exit_code.value != 0:
+    if func.restype is c_error:
+        raise_if_error(exit_code.value)
+
+    return exit_code
+
+
+def raise_if_error(error_code):
+    if error_code != 0:
         raise {
             -1: UnspecifiedError,
             -2: FileUnsupported,
@@ -138,6 +145,4 @@ def check_call(exit_code, func, arguments):
             -100009: IOError,
             -100010: CancelledByCallback,
             -100011: BadCrop
-        }[exit_code.value]
-
-    return exit_code
+        }[error_code]

--- a/rawkit/raw.py
+++ b/rawkit/raw.py
@@ -10,6 +10,7 @@ import tempfile
 
 from collections import namedtuple
 from libraw.bindings import LibRaw
+from libraw.errors import raise_if_error
 
 from rawkit.errors import InvalidFileType
 from rawkit.errors import NoFileSpecified
@@ -151,11 +152,15 @@ class Raw(object):
         self.unpack()
         self.process()
 
-        # TODO: check the error code stored in the provided int pointer
+        status = ctypes.c_int(0)
         processed_image = self.libraw.libraw_dcraw_make_mem_image(
             self.data,
-            ctypes.byref(ctypes.c_int()),
+            ctypes.cast(
+                ctypes.addressof(status),
+                ctypes.POINTER(ctypes.c_int),
+            ),
         )
+        raise_if_error(status.value)
         data_pointer = ctypes.cast(
             processed_image.contents.data,
             ctypes.POINTER(ctypes.c_byte * processed_image.contents.data_size)
@@ -174,11 +179,15 @@ class Raw(object):
         """
         self.unpack_thumb()
 
-        # TODO: check the error code stored in the provided int pointer
+        status = ctypes.c_int(0)
         processed_image = self.libraw.libraw_dcraw_make_mem_thumb(
             self.data,
-            ctypes.byref(ctypes.c_int()),
+            ctypes.cast(
+                ctypes.addressof(status),
+                ctypes.POINTER(ctypes.c_int),
+            ),
         )
+        raise_if_error(status.value)
         data_pointer = ctypes.cast(
             processed_image.contents.data,
             ctypes.POINTER(ctypes.c_byte * processed_image.contents.data_size)

--- a/tests/unit/raw_test.py
+++ b/tests/unit/raw_test.py
@@ -138,7 +138,8 @@ def test_save_thumb_no_filename(raw):
 def test_to_buffer(raw):
     # Quick hack because to_buffer does some ctypes acrobatics
     with mock.patch('rawkit.raw.ctypes'):
-        raw.to_buffer()
+        with mock.patch('rawkit.raw.raise_if_error'):
+            raw.to_buffer()
 
     raw.libraw.libraw_dcraw_make_mem_image.assert_called_once_with(
         raw.data,
@@ -153,7 +154,8 @@ def test_to_buffer(raw):
 def test_thumbnail_to_buffer(raw):
     # Quick hack because thumbnail_to_buffer does some ctypes acrobatics
     with mock.patch('rawkit.raw.ctypes'):
-        raw.thumbnail_to_buffer()
+        with mock.patch('rawkit.raw.raise_if_error'):
+            raw.thumbnail_to_buffer()
 
     raw.libraw.libraw_dcraw_make_mem_thumb.assert_called_once_with(
         raw.data,


### PR DESCRIPTION
Check the error codes from the make_mem functions. I wasn't actually able to cause `make_mem_image` to throw an error, but `make_mem_thumb` would and they're using the same code. I suspect there may be an issue with LibRaw, but I'll need to investigate more. For now this is OK to merge though.