### PR TITLE
Added color function and updated bayer_data function

### DIFF
--- a/libraw/bindings.py
+++ b/libraw/bindings.py
@@ -152,7 +152,7 @@ class LibRaw(CDLL):
             libraw_processed_image_t)
         self.libraw_raw2image.restype = c_error
         self.libraw_get_decoder_info.restype = c_error
-        self.libraw_COLOR.restype = c_error
+        self.libraw_COLOR.restype = c_int
 
         # Some special Windows-only garbage:
 


### PR DESCRIPTION
Changing things up a little because we made some mistakes the first time around. `cdesc` doesn't actually reflect color order, and in fact can't for sensors with non-standard pattern sizes. Instead you're supposed to use the `libraw_COLOR` to get the color of a specific pixel. I have added the `Raw.color` method to address this, and removed `cdesc` from the `bayer_data` function because it wasn't used for what we thought it was. Now you would use the code something like this:

```python
from rawkit.raw import Raw


with Raw(filename='some_file.CR2') as raw:

    bayer_data = raw.bayer_data()

    row = 100
    col = 100

    print('pixel value is %s.' % bayer_data[row][col])
    print('pixel color is %s.' % raw.color(row, col))
```

This would give you output like:

```
pixel value is 5725.
pixel color is R.
```