### PR TITLE
Make PEP8 shut up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ language: python
 # Keep up to date with the tox.ini list
 env:
   - TOXENV=py27
-  - TOXENV=py34
+  - TOXENV=py36
   - TOXENV=pypy
-  - TOXENV=pypy3
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 sudo: false
 language: python
-# Keep up to date with the tox.ini list
-env:
-  - TOXENV=py27
-  - TOXENV=py36
-  - TOXENV=pypy
+matrix:
+  # Keep up to date with the tox.ini list
+  include:
+    - python: pypy
+      env: TOXENV=pypy
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 2.7
+      env: TOXENV=py27
 addons:
   apt:
     packages:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 REBUILD_FLAG =
 VENV=env
 BIN=$(VENV)/bin
-ACTIVATE=source $(BIN)/activate
+ACTIVATE=. $(BIN)/activate
 APIDOCS=docs/source/api
 DOCSRC=$(APIDOCS)/modules.rst docs/source/* docs/source/_static/*
 

--- a/rawkit/options.py
+++ b/rawkit/options.py
@@ -77,6 +77,7 @@ class option(object):
             # We're probably generating the documentation...
             return self
 
+
 highlight_modes = namedtuple(
     'HighlightMode', ['clip', 'ignore', 'blend', 'reconstruct']
 )(0, 1, 2, 5)

--- a/rawkit/raw.py
+++ b/rawkit/raw.py
@@ -97,11 +97,12 @@ class Raw(object):
     def unpack_thumb(self):
         """
         Unpack the thumbnail data.
+
         Raises:
             libraw.errors.NoThumbnail: If the raw file does not contain a
-                                       thumbnail.
+            thumbnail.
             libraw.errors.UnsupportedThumbnail: If the thumbnail format is
-                                                unsupported.
+            unsupported.
         """
         if not self.thumb_unpacked:
             self.libraw.libraw_unpack_thumb(self.data)
@@ -213,12 +214,13 @@ class Raw(object):
         Returns:
             list: 2D array representing the color format array pattern.
                   For example, the typical 'RGGB' pattern of abayer sensor
-                  would be of the format:
+                  would be of the format::
 
-                  [
-                      ['R', 'G'],
-                      ['G', 'B'],
-                  ]
+                      [
+                          ['R', 'G'],
+                          ['G', 'B'],
+                      ]
+
         """
 
         # TODO: don't assume 2x2 bayer sensor
@@ -236,14 +238,15 @@ class Raw(object):
             list: 2D array of bayer pixel data structured as a list of rows,
                   or None if there is no bayer data.
                   For example, if the color format is `RGGB`, the array
-                  would be of the format:
+                  would be of the format::
 
-                  [
-                      [R, G, R, G, ...],
-                      [G, B, G, B, ...],
-                      [R, G, R, G, ...],
-                      ...
-                  ]
+                      [
+                          [R, G, R, G, ...],
+                          [G, B, G, B, ...],
+                          [R, G, R, G, ...],
+                          ...
+                      ]
+
         """
         self.unpack()
         image = self.data.contents.rawdata.raw_image

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ def readme():
     with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as f:
         return f.read()
 
+
 setup(
     name='rawkit',
     version=VERSION,

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 project = rawkit
 # Keep up to date with the .travis.yml list
-envlist = py{27,35,py,py3}
+envlist = py{27,36,py}
 
 [testenv]
 deps =


### PR DESCRIPTION
PEP8 is complaining for some reason; not sure when it happened as everything looks green on master. Oh wel, fixed.

Also fix CI matrix and python versions.

*EDIT:* Looks like Travis changed something and their Pytohn 3.6 build environment is not consistent with the other ones; try to work around it.