### PR TITLE
Partially handle exif orientation

### DIFF
--- a/rawkit/orientation.py
+++ b/rawkit/orientation.py
@@ -1,0 +1,12 @@
+exif_orientation_map = {
+    0: 1,
+    6: 6,
+    3: 3,
+    5: 8,
+}
+
+
+def get_orientation(data):
+    # TODO: find a way to handle mirrored images
+    # See https://github.com/photoshell/rawkit/issues/120 for more context
+    return exif_orientation_map.get(data.contents.sizes.flip, 1)

--- a/rawkit/raw.py
+++ b/rawkit/raw.py
@@ -17,6 +17,7 @@ from rawkit.errors import InvalidFileType
 from rawkit.errors import NoFileSpecified
 from rawkit.metadata import Metadata
 from rawkit.options import Options
+from rawkit.orientation import get_orientation
 
 
 output_file_types = namedtuple(
@@ -379,7 +380,7 @@ class Raw(object):
             iso=self.data.contents.other.iso_speed,
             make=self.data.contents.idata.make,
             model=self.data.contents.idata.model,
-            orientation=self.data.contents.sizes.flip,
+            orientation=get_orientation(self.data),
             width=self.data.contents.sizes.width,
         )
 


### PR DESCRIPTION
This changes `metadata.orientation` to use correct exif orientation values for non-mirrored images. Mirrored images are still unsupported.