### PR TITLE
python3.7 compatibility: Generators should not raise StopIteration

### DIFF
--- a/rawkit/options.py
+++ b/rawkit/options.py
@@ -255,7 +255,7 @@ class Options(object):
             try:
                 yield self.keys()[idx - 1]
             except IndexError:
-                raise StopIteration
+                return
 
     def __repr__(self):
         """Represents the options as a dict."""


### PR DESCRIPTION
See PEP 479