### PR TITLE
Test against Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ matrix:
   include:
     - python: pypy
       env: TOXENV=pypy
-    - python: 3.6
-      env: TOXENV=py36
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env: TOXENV=py37
     - python: 2.7
       env: TOXENV=py27
 addons:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 project = rawkit
 # Keep up to date with the .travis.yml list
-envlist = py{27,36,py}
+envlist = py{27,37,py}
 
 [testenv]
 deps =


### PR DESCRIPTION
Does what it says on the tin. I don't remember if we had a policy for what version to test against, but 3.7 has been out for a while now so it seemed reasonable.